### PR TITLE
Links ESPN for Canal Digitaal

### DIFF
--- a/build-source/snp.index
+++ b/build-source/snp.index
@@ -1,3 +1,6 @@
+17CC_C82_3_EB0000=espn
+espn2hd=espn2
+espn4hd=espn4
 11856vsid0x200d=bsmart
 2078_432_1_C00000=canalplusalaune
 canalplusalademande=canalsatalademande


### PR DESCRIPTION
Issue #441
After more than two weeks someone at Canal Digitaal woke up and changed the stationnames. I think someone overthere should go in the mascot suit, not Hans Kraay jr. LOL
https://www.facebook.com/ESPNNL/videos/1006766506481399/