### PR TITLE
Add DVB T2 Czech tv channels new naming

### DIFF
--- a/build-source/snp.index
+++ b/build-source/snp.index
@@ -1,3 +1,9 @@
+ctdarthdt2=ctd_ctart
+ct1hdt2=ct1hd
+ct2hdt2=ct2hd
+ct3hdt2=ct3hd
+ct24hdt2=ct24hd
+ctsporthdt2=ctsporthd
 D_1_1_A0B0F9=atv-uucanimeth
 1_1_1_A0B0F9=kohavision
 radio21kosovo=radio21-wricobrufr


### PR DESCRIPTION
Hi, i spotted on my Enigma2 vu+duo that Ceska Televize  dvbt2  channels have no picons due to added T2 in multiplex naming, added this to code... Hope this is enough. 