### PR TITLE
BBC One South (UK Freeview)

### DIFF
--- a/build-source/snp.index
+++ b/build-source/snp.index
@@ -1,3 +1,4 @@
+bbconesouth=bbcone
 bbconesthhd=bbcone
 191F_7F5_2_11A0000=bbcradio1
 2301_80D_2_11A0000=bbcradio1


### PR DESCRIPTION
For Freeview.
Add entry for bbconesouth in snp.index
Entry for my local Freeview transmitter (Hannington) in srp.index is already present.

Presumably other regions have also changed to include the region in the name of BBC One.