### PR TITLE
[28.2E] Channel 5 is now just 5

### DIFF
--- a/build-source/snp.index
+++ b/build-source/snp.index
@@ -1,3 +1,16 @@
+5hd=channel5
+5plus1=channel5plus1
+835_83D_2_11A0000=channel5
+2134_2002_233A_EEEE0000=channel5
+2134_2005_233A_EEEE0000=channel5
+2134_2006_233A_EEEE0000=channel5
+2134_200C_233A_EEEE0000=channel5
+2134_200E_233A_EEEE0000=channel5
+2134_200F_233A_EEEE0000=channel5
+2134_2011_233A_EEEE0000=channel5
+2134_2012_233A_EEEE0000=channel5
+2134_2015_233A_EEEE0000=channel5
+2134_2019_233A_EEEE0000=channel5
 viaplaytvplus=viaplaytvplus
 bettvheiloo=beattv
 saltobrasatvamsterdam=brasatelevisie


### PR DESCRIPTION
Channel 5 is now just 5. 5 is already the name of a TV channel in the Philippines.
This PR is the changes to snp.index for this.
Hopefully I have dealt with that in the correct way by copying some lines from srp.index to use in snp.index where the channel name is not unique.