### PR TITLE
Add abbreviation for CNN international

### DIFF
--- a/build-source/utf8snp.index
+++ b/build-source/utf8snp.index
@@ -2293,6 +2293,7 @@ cnn international europe=cnn
 cnn international hd=cnn
 cnn international=cnn
 cnn intl=cnn
+cnn int.=cnn
 cnn=cnn
 cnni emea hd=cnn
 cnni sd=cnn


### PR DESCRIPTION
Logo for CNN Int. on Astra is not found. I added a line:
`cnn int.=cnn` to the utf8snp.index
