### PR TITLE
Delete a redundant link.

### DIFF
--- a/build-source/utf8snp.index
+++ b/build-source/utf8snp.index
@@ -1622,7 +1622,6 @@ amsterdamfm=amsterdamfm
 amsterdam funk channel=amsterdamfunkchannel
 amsterdamfunkchannel=amsterdamfunkchannel
 amw = amsterdams most wanted=amsterdamsmostwanted
-amw  amsterdams most wanted=amsterdamsmostwanted
 amwamsterdamsmostwanted=amsterdamsmostwanted
 anadolu dernek tv=anadoludernek
 anadoludernektv=anadoludernek


### PR DESCRIPTION
Our code has been updated to allow an "=" sign in the service/channel name. Enigma2 has always supported "=" when utf8snp was introduced.