### PR TITLE
[Control file] Add "Conflicts" for utf8snp

### DIFF
--- a/2-build-picons.sh
+++ b/2-build-picons.sh
@@ -257,6 +257,7 @@ grep -v -e '^#' -e '^$' $backgroundsconf | while read lines ; do
 		if [[ "$style" == "utf8snp" ]] || [[ "$style" == "utf8snp-full" ]]; then
 			echo "Provides: enigma2-plugin-picons-snp-${packagenamenoversion:8}" >> $temp/package/CONTROL/control
 			echo "Replaces: enigma2-plugin-picons-snp-${packagenamenoversion:8}" >> $temp/package/CONTROL/control
+			echo "Conflicts: enigma2-plugin-picons-snp-${packagenamenoversion:8}" >> $temp/package/CONTROL/control
 		fi
         touch --no-dereference -t $timestamp $temp/package/CONTROL/control
         $location/resources/tools/ipkg-build.sh -o root -g root $temp/package $binaries >> $logfile


### PR DESCRIPTION
A recommended by an OpenATV developer.
This is so that utf8snp packages replace snp ones automatically. Follows on from: https://github.com/picons/picons/commit/09bb06ea50c15a5648e457e163f635543a6650ca