### PR TITLE
building on tvheadend

### DIFF
--- a/1-build-servicelist.sh
+++ b/1-build-servicelist.sh
@@ -204,10 +204,11 @@ if [[ -f $location/build-input/tvheadend.serverconf ]]; then
 
             if [[ $style = "utf8snp" ]]; then
                 channelname=$channelname_raw
-                # Force NFD to match decomposed entries in utf8snp.index
-                utf8snpname=$(python3 -c "import unicodedata,sys; print(unicodedata.normalize('NFD', sys.argv[1]))" "$channelname" | sed -e 's/\(.*\)/\L\1/g' -e 's/[<>:"\/\\|?*]//g' -e 's/\.\+$//')
+                # TVHeadend uses NFC for filenames; normalise to NFD only for index lookup, then convert back to NFC for output
+                utf8snpname_nfd=$(python3 -c "import unicodedata,sys; print(unicodedata.normalize('NFD', sys.argv[1]))" "$channelname" | sed -e 's/\(.*\)/\L\1/g' -e 's/[<>:"\/\\|?*]//g' -e 's/\.\+$//')
+                utf8snpname=$(python3 -c "import unicodedata,sys; print(unicodedata.normalize('NFC', sys.argv[1]))" "$channelname" | sed -e 's/\(.*\)/\L\1/g')
                 if [[ -z $utf8snpname ]]; then utf8snpname="--------"; fi
-                logo_utf8snp=$(grep -i -m 1 "^$utf8snpname=" <<< "$index" | sed -n -e 's/.*=//p')
+                logo_utf8snp=$(grep -i -m 1 "^$utf8snpname_nfd=" <<< "$index" | sed -n -e 's/.*=//p')
                 if [[ -z $logo_utf8snp ]]; then logo_utf8snp="--------"; fi
                 echo -e "$serviceref\t$channelname\t$serviceref_id=$logo_srp\t$utf8snpname=$logo_utf8snp" >> $tempfile
             elif [[ $style = "snp" ]]; then

--- a/2-build-picons.sh
+++ b/2-build-picons.sh
@@ -265,7 +265,7 @@ grep -v -e '^#' -e '^$' $backgroundsconf | while read lines ; do
 
     mv $temp/package/picon $temp/package/$packagename
 
-    tar --dereference --owner=root --group=root -cf - --exclude=logos --directory=$temp/package $packagename | $compressor 2>> $logfile > $binaries/$packagename.hardlink.tar.$ext
+    tar --dereference --owner=root --group=root -cf - --exclude=logos --exclude='*%*' --directory=$temp/package $packagename | $compressor 2>> $logfile > $binaries/$packagename.hardlink.tar.$ext
     tar --owner=root --group=root -cf - --directory=$temp/package $packagename | $compressor 2>> $logfile > $binaries/$packagename.symlink.tar.$ext
 
     find $binaries -exec touch -t $timestamp {} \;

--- a/resources/tools/create-symlinks.sh
+++ b/resources/tools/create-symlinks.sh
@@ -39,30 +39,44 @@ fi
 ## Create symlinks for UTF8SNP using servicelist ##
 ##############################################################
 if [[ $style = "utf8snp" ]]; then
-    cat $location/build-output/servicelist-*-$style.txt | sed 's/\r//' | tr -d [=*=] | while read line ; do
-        IFS="|"
-        line_data=($line)
-        serviceref=$(echo "${line_data[0]}" | tr -d [:blank:])
-        link_srp=$(echo "${line_data[2]}" | tr -d [:blank:])
+    for servicelist in $location/build-output/servicelist-*-$style.txt ; do
+        # TVHeadend uses %U (UTF-8 URL-encoded) picon filenames, so we need extra URL-encoded symlinks
+        [[ $servicelist == *"tvheadend"* ]] && is_tvheadend=true || is_tvheadend=false
 
-        IFS="="
-        link_srp=($link_srp)
-        logo_srp=${link_srp[1]}
+        while read line ; do
+            IFS="|"
+            line_data=($line)
+            serviceref=$(echo "${line_data[0]}" | tr -d [:blank:])
+            link_srp=$(echo "${line_data[2]}" | tr -d [:blank:])
 
-        # for utf8snp we split on last occurance of = because the channel name may contain =, and that is valid
-        # column 4 is read without stripping blanks to preserve spaces in utf8snpname
-        link_utf8snp=$(echo "${line_data[3]}" | sed 's/^[[:blank:]]*//' | sed 's/[[:blank:]]*$//')
-        split_char="="
-        logo_utf8snp="${link_utf8snp##*${split_char}}"
-        utf8snpname=`echo ${link_utf8snp%${split_char}*} | sed "s/'/'\"'\"'/g"`  # escape single quotes
+            IFS="="
+            link_srp=($link_srp)
+            logo_srp=${link_srp[1]}
 
-        if [[ ! $logo_srp = "--------" ]]; then
-            echo "ln -s -f 'logos/$logo_srp.png' '$temp/package/picon/$serviceref.png'" >> $temp/create-symlinks.sh
-        fi
+            # for utf8snp we split on last occurance of = because the channel name may contain =, and that is valid
+            # column 4 is read without stripping blanks to preserve spaces in utf8snpname
+            link_utf8snp=$(echo "${line_data[3]}" | sed 's/^[[:blank:]]*//' | sed 's/[[:blank:]]*$//')
+            split_char="="
+            logo_utf8snp="${link_utf8snp##*${split_char}}"
+            utf8snpname_raw=${link_utf8snp%${split_char}*}  # raw name for URL encoding
+            utf8snpname=`echo "$utf8snpname_raw" | sed "s/'/'\"'\"'/g"`  # escape single quotes for shell output
 
-        if [[ ! $logo_utf8snp = "--------" ]]; then
-            echo "ln -s -f 'logos/$logo_utf8snp.png' '$temp/package/picon/$utf8snpname.png'" >> $temp/create-symlinks.sh
-        fi
+            if [[ ! $logo_srp = "--------" ]]; then
+                echo "ln -s -f 'logos/$logo_srp.png' '$temp/package/picon/$serviceref.png'" >> $temp/create-symlinks.sh
+            fi
+
+            if [[ ! $logo_utf8snp = "--------" ]]; then
+                echo "ln -s -f 'logos/$logo_utf8snp.png' '$temp/package/picon/$utf8snpname.png'" >> $temp/create-symlinks.sh
+                # TVHeadend uses %U (UTF-8 URL-encoded) picon filenames, create an additional symlink to match
+                if [[ $is_tvheadend = true ]]; then
+                    urlencoded_name=$(python3 -c "import urllib.parse,unicodedata,sys; print(urllib.parse.quote(unicodedata.normalize('NFC', sys.argv[1]), safe=''))" "$utf8snpname_raw")
+                    if [[ ! "$urlencoded_name" = "$utf8snpname_raw" ]]; then
+                        urlencoded_name_escaped=$(echo "$urlencoded_name" | sed "s/'/'\"'\"'/g")
+                        echo "ln -s -f 'logos/$logo_utf8snp.png' '$temp/package/picon/$urlencoded_name_escaped.png'" >> $temp/create-symlinks.sh
+                    fi
+                fi
+            fi
+        done < <(sed 's/\r//' "$servicelist" | tr -d '*')
     done
 fi
 


### PR DESCRIPTION
build-servicelist.sh — NFD/NFC normalisation fix for TVHeadend

resources/tools/create-symlinks.sh — TVHeadend URL-encoding + single quote fix 

build-picons.sh — exclude URL-encoded filenames from hardlink tar