### PR TITLE
[create-symlinks.sh] Preserve double spaces in utf8snp-full picon 

### DIFF
--- a/resources/tools/create-symlinks.sh
+++ b/resources/tools/create-symlinks.sh
@@ -120,7 +120,7 @@ if [[ $style = "utf8snp-full" ]]; then
         # for utf8snp we split on last occurance of = because the channel name may contain =, and that is valid
         split_char="="
         logo_utf8snp="${line##*${split_char}}"
-        utf8snpname=`echo ${line%${split_char}*} | sed "s/'/'\"'\"'/g"`  # escape single quotes
+        utf8snpname=`echo "${line%${split_char}*}" | sed "s/'/'\"'\"'/g"`  # escape single quotes
 
         if [[ $utf8snpname =~ ^[0-9A-F]+[_][0-9A-F]+[_][0-9A-F]+[_][0-9A-F]+$ ]]; then
             echo "ln -s -f 'logos/$logo_utf8snp.png' '$temp/package/picon/1_0_1_"$utf8snpname"_0_0_0.png'" >> $temp/create-symlinks.sh


### PR DESCRIPTION
Unquoted variable expansion in the utf8snp-full section caused bash word splitting to collapse consecutive spaces before passing the string to echo. This meant channel names where Enigma2 removes a separator character (e.g. "/" in "UHD1 by ASTRA / HD+") and leaves a double space would have the second space dropped, producing a picon filename that no longer matched the Enigma2 lookup key.

Fix by quoting the parameter expansion in the echo call so word splitting does not occur.