### PR TITLE
Tweak automated releases to Upstream.

### DIFF
--- a/.github/workflows/cleanup-releases.yml
+++ b/.github/workflows/cleanup-releases.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   cleanup:
     runs-on: ubuntu-latest
+    if: github.repository == 'picons/picons' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Delete old releases
         env:

--- a/.github/workflows/create-release-13e19e23e28e.yml
+++ b/.github/workflows/create-release-13e19e23e28e.yml
@@ -8,6 +8,7 @@ jobs:
   create-release-13e19e23e28e:
     name: Create 13e.19e.23e.28e Release
     runs-on: ubuntu-latest
+    if: github.repository == 'picons/picons' || github.event_name == 'workflow_dispatch'
     outputs:
       version: ${{steps.version.outputs.version}}
     steps:

--- a/.github/workflows/create-release-ziggo.yml
+++ b/.github/workflows/create-release-ziggo.yml
@@ -8,6 +8,7 @@ jobs:
   create-release-ziggo:
     name: Create Ziggo Release
     runs-on: ubuntu-latest
+    if: github.repository == 'picons/picons' || github.event_name == 'workflow_dispatch'
     outputs:
       version: ${{steps.version.outputs.version}}
     steps:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -8,6 +8,7 @@ jobs:
   create-release:
     name: Create Release
     runs-on: ubuntu-latest
+    if: github.repository == 'picons/picons' || github.event_name == 'workflow_dispatch'
     outputs:
       version: ${{steps.version.outputs.version}}
     steps:


### PR DESCRIPTION
People can still manually start a release on their fork.