### PR TITLE
Build using filtered srp.index

### DIFF
--- a/1-build-servicelist.sh
+++ b/1-build-servicelist.sh
@@ -59,6 +59,23 @@ if [[ ! $style = "srp" ]] && [[ ! $style = "snp" ]] && [[ ! $style = "utf8snp" ]
     exit 1
 fi
 
+##########################################################################################
+## Optional orbital-position (namespace) filter - srp only.                             ##
+## Builds straight from the index for the chosen position(s),                           ##
+## with no lamedb/bouquet read at all. snp/utf8snp index keys                           ##
+## carry no namespace, so filtering isn't possible for those;                           ##
+## they always run the full lamedb/bouquet match instead.                               ##
+## Usage: ./1-build-servicelist.sh srp 11A,600_FFFF                                     ##
+## Usage: ./1-build-servicelist.sh srp all       (every index entry, no lamedb/bouquet) ##
+## Usage: ./1-build-servicelist.sh srp enigma2   (lamedb/bouquet build, unchanged)      ##
+##########################################################################################
+nsfilter="${*:2}"
+
+if [[ -n $nsfilter ]] && [[ ! $style = "srp" ]]; then
+    echo "$(date +'%H:%M:%S') - INFO: Orbital-position filter ignored: not supported for style \"$style\", running the full lamedb/bouquet match instead."
+    nsfilter=""
+fi
+
 #####################
 ## Read index file ##
 #####################
@@ -67,7 +84,313 @@ index=$(<"$location/build-source/$style.index")
 ##################################
 ## Enigma2 servicelist creation ##
 ##################################
-if [[ -d $location/build-input/enigma2 ]]; then
+
+#######################################################################
+## srp only: work out which orbital position(s) to build.            ##
+## The last 4 hex digits of a namespace are the "subnet" (varies     ##
+## per multi-feed transponder), so we group/match on the orbital     ##
+## prefix only, e.g. 11Axxxx rather than 11A0000. Cable (FFFFxxxx)   ##
+## and Terrestrial (EEEExxxx) aren't tied to a physical position -   ##
+## every operator on cable/terrestrial shares that same namespace    ##
+## prefix, so those two are additionally keyed by onid (e.g.         ##
+## 600_FFFFxxxx, 233A_EEEExxxx) to tell operators apart.             ##
+##                                                                   ##
+## Choosing specific orbital position(s), or "all", builds straight  ##
+## from the $style.index file - no lamedb or bouquet files are read  ##
+## or required. Choosing "enigma2" builds against your enigma2       ##
+## folder (lamedb/bouquet), exactly as before.                       ##
+#######################################################################
+
+#####################################################################
+## Friendly names for Cable/Terrestrial onids - most people won't  ##
+## recognise a bare onid, so fill this in as you identify them.    ##
+## Format: [onid]="Friendly Name". Uncomment/add lines as needed.  ##
+#####################################################################
+declare -A ns_onid_names=(
+		[1_EEEE0000]="Luxembourg"
+		[20FA_EEEE0000]="France"
+		[2114_EEEE0000]="Germany"
+		[2174_EEEE0000]="Saorview"
+        [2038_EEEE0000]="Belgium"
+        [22FC_EEEE0000]="Thailand"
+        [233A_EEEE0000]="UK Freeview"
+        [531_EEEE0000]="Portugal"
+        [600_FFFF0000]="NLD Ziggo"
+        [8C9_FFFF0000]="NLD Caiway"
+        [10EF_FFFF0000]="NLD Delta"
+        [25A8_FFFF0000]="NLD SKV"
+)
+
+#####################################################################
+## Which named Cable/Terrestrial entries are "common" enough to    ##
+## also appear in the Common Providers section. Separate from      ##
+## ns_onid_names above - naming something doesn't automatically    ##
+## feature it here. Key format: onid_FFFF or onid_EEEE (no 0000).  ##
+## Listed in the order given here (your priority order).           ##
+#####################################################################
+ns_common_providers=(
+    600_FFFF   # NLD Ziggo
+    233A_EEEE  # UK Freeview
+)
+
+#####################################################################
+## Common/frequently-used orbital positions, shown at the top of   ##
+## the menu ahead of the full list so they're not lost among the   ##
+## ~100 positions most people never need. Hex prefix only, no      ##
+## names. Listed in the order given here (your priority order) -   ##
+## add/remove/reorder as needed.                                   ##
+#####################################################################
+ns_common_orbital=(
+    82   # 13.0E
+    C0   # 19.2E
+    EB   # 23.5E
+    11A  # 28.2E
+)
+
+ns_label() {
+    local key=$1 prefix onid dec deg label name
+    if [[ $key == *_* ]]; then onid=${key%_*}; prefix=${key#*_}; else prefix=$key; fi
+    case $prefix in
+        FFFF) name=${ns_onid_names[${onid}_FFFF0000]}; label=${name:-Cable} ;;
+        EEEE) name=${ns_onid_names[${onid}_EEEE0000]}; label=${name:-Terrestrial} ;;
+        *)
+            dec=$((16#$prefix))
+            if (( dec > 3599 )); then
+                label="Unclassified"
+            elif (( dec <= 1800 )); then
+                deg=$(awk -v d="$dec" 'BEGIN{printf "%.1f", d/10}')
+                label="${deg}°E"
+            else
+                deg=$(awk -v d="$dec" 'BEGIN{printf "%.1f", (3600-d)/10}')
+                label="${deg}°W"
+            fi
+            ;;
+    esac
+    if [[ -n $onid ]]; then echo "$label (${onid}_${prefix}0000)"; else echo "$label (namespace ${prefix}xxxx)"; fi
+}
+ns_pattern_index() {
+    local key=$1 prefix onid
+    if [[ $key == *_* ]]; then
+        onid=${key%_*}; prefix=${key#*_}
+        echo "_${onid}_${prefix}[0-9A-F]{4}="
+    else
+        prefix=$key
+        echo "_${prefix}[0-9A-F]{4}="
+    fi
+}
+normalize_ns_token() {
+    local tok=${1^^} onid prefix deg dir dec
+    if [[ $tok == *_* ]]; then onid=${tok%_*}; prefix=${tok#*_}; else prefix=$tok; fi
+    if [[ $prefix =~ ^([0-9]+(\.[0-9]+)?)(E|W)\.?$ ]]; then
+        deg=${BASH_REMATCH[1]}; dir=${BASH_REMATCH[3]}
+        if [[ $dir = "E" ]]; then
+            dec=$(awk -v d="$deg" 'BEGIN{printf "%d", (d*10)+0.5}')
+        else
+            dec=$(awk -v d="$deg" 'BEGIN{printf "%d", (3600-(d*10))+0.5}')
+        fi
+        prefix=$(printf '%X' "$dec")
+    else
+        prefix=${prefix%XXXX}
+        if [[ $prefix =~ ^[0-9A-F]+$ ]] && [[ ${#prefix} -gt 4 ]]; then
+            prefix=${prefix:0:${#prefix}-4}
+        fi
+    fi
+    if [[ -n $onid ]]; then echo "${onid}_${prefix}"; else echo "$prefix"; fi
+}
+
+ns_group_and_sort() {
+    # Reads $ns_available (newline list of keys) into sorted globals:
+    # ns_cable, ns_terrestrial (by onid, numeric), ns_satellite (by
+    # signed degree, West negative -> East positive, ascending), and
+    # ns_other (out-of-range namespace values, by hex, listed last).
+    local key prefix onid dec signed
+    ns_cable=() ; ns_terrestrial=() ; ns_satellite=() ; ns_other=()
+    while read -r key; do
+        [[ -z $key ]] && continue
+        if [[ $key == *_* ]]; then onid=${key%_*}; prefix=${key#*_}; else prefix=$key; onid=""; fi
+        case $prefix in
+            FFFF) ns_cable+=("$key") ;;
+            EEEE) ns_terrestrial+=("$key") ;;
+            *) if (( $((16#$prefix)) > 3599 )); then ns_other+=("$key"); else ns_satellite+=("$key"); fi ;;
+        esac
+    done <<< "$ns_available"
+
+    if [[ ${#ns_cable[@]} -gt 0 ]]; then
+        ns_cable=($(for key in "${ns_cable[@]}"; do
+            onid=${key%_*}; named=0; [[ -n ${ns_onid_names[${key}0000]:-} ]] && named=1
+            printf '%d\t%d\t%s\n' "$named" "$((16#$onid))" "$key"
+        done | sort -n -k1,1 -k2,2 | cut -f3))
+    fi
+    if [[ ${#ns_terrestrial[@]} -gt 0 ]]; then
+        ns_terrestrial=($(for key in "${ns_terrestrial[@]}"; do
+            onid=${key%_*}; named=0; [[ -n ${ns_onid_names[${key}0000]:-} ]] && named=1
+            printf '%d\t%d\t%s\n' "$named" "$((16#$onid))" "$key"
+        done | sort -n -k1,1 -k2,2 | cut -f3))
+    fi
+    if [[ ${#ns_satellite[@]} -gt 0 ]]; then
+        ns_satellite=($(for key in "${ns_satellite[@]}"; do
+            dec=$((16#$key))
+            if (( dec <= 1800 )); then signed=$dec; else signed=$(( -(3600-dec) )); fi
+            printf '%d\t%s\n' "$signed" "$key"
+        done | sort -n -k1,1 | cut -f2))
+    fi
+    if [[ ${#ns_other[@]} -gt 0 ]]; then
+        ns_other=($(for key in "${ns_other[@]}"; do printf '%d\t%s\n' "$((16#$key))" "$key"; done | sort -n -k1,1 | cut -f2))
+    fi
+
+    ns_named=()
+    for key in "${ns_common_providers[@]}"; do
+        for candidate in "${ns_cable[@]}" "${ns_terrestrial[@]}"; do
+            [[ $candidate = "$key" ]] && ns_named+=("$key")
+        done
+    done
+
+    ns_common=()
+    for prefix in "${ns_common_orbital[@]}"; do
+        for key in "${ns_satellite[@]}"; do
+            [[ $key = "$prefix" ]] && ns_common+=("$key")
+        done
+    done
+}
+
+resolve_ns_token() {
+    # Resolves one answer/CLI token to one or more group keys (one per
+    # line). Tries, in order: an exact menu number (interactive only),
+    # a rough (case-insensitive substring) match against named Cable/
+    # Terrestrial entries, then normalize_ns_token (hex/xxxx/degree/
+    # onid_prefix). Prints nothing if none of these match.
+    local tok=$1 upper key found=0
+    if [[ $tok =~ ^[0-9]+$ ]] && [[ -n ${ns_menu[$tok]:-} ]]; then
+        echo "${ns_menu[$tok]}"
+        return
+    fi
+    upper=${tok^^}
+    for key in "${ns_cable[@]}" "${ns_terrestrial[@]}"; do
+        if [[ -n ${ns_onid_names[${key}0000]:-} ]] && [[ ${ns_onid_names[${key}0000]^^} == *"$upper"* ]]; then
+            echo "$key"
+            found=1
+        fi
+    done
+    if [[ $found -eq 1 ]]; then return; fi
+    normalize_ns_token "$tok"
+}
+
+ns_mode="full"
+unset ns_menu; declare -A ns_menu
+if [[ $style = "srp" ]]; then
+    ns_available=$(awk -F'=' '{print $1}' <<< "$index" | awk -F'_' '{ns=$NF; onid=$(NF-1); prefix=(length(ns)>4)?substr(ns,1,length(ns)-4):ns; if (prefix=="FFFF" || prefix=="EEEE") print onid"_"prefix; else print prefix}' | sort -u)
+    ns_group_and_sort
+
+    if [[ -n $nsfilter ]]; then
+        case $nsfilter in
+            all) ns_mode="index" ;;
+            enigma2) ns_mode="full" ;;
+            *)
+                ns_mode="orbital"
+                ns_selected=$(tr ',' '\n' <<< "$nsfilter" | while read -r tok; do resolve_ns_token "$tok"; done | sort -u)
+                ;;
+        esac
+    else
+        echo "Which orbital position(s) do you want to build?"
+        i=0
+        if [[ ${#ns_satellite[@]} -gt 0 ]]; then
+            echo "-- Satellite positions --"
+            for key in "${ns_satellite[@]}"; do ((i++)); ns_menu[$i]=$key; echo "  $i) $(ns_label "$key")"; done
+        fi
+        if [[ ${#ns_cable[@]} -gt 0 ]]; then
+            echo "-- Cable --"
+            for key in "${ns_cable[@]}"; do ((i++)); ns_menu[$i]=$key; echo "  $i) $(ns_label "$key")"; done
+        fi
+        if [[ ${#ns_terrestrial[@]} -gt 0 ]]; then
+            echo "-- Terrestrial --"
+            for key in "${ns_terrestrial[@]}"; do ((i++)); ns_menu[$i]=$key; echo "  $i) $(ns_label "$key")"; done
+        fi
+        if [[ ${#ns_other[@]} -gt 0 ]]; then
+            echo "-- Unclassified --"
+            for key in "${ns_other[@]}"; do ((i++)); ns_menu[$i]=$key; echo "  $i) $(ns_label "$key")"; done
+        fi
+        if [[ ${#ns_common[@]} -gt 0 ]] || [[ ${#ns_named[@]} -gt 0 ]]; then
+            echo "-- Common Positions/Providers --"
+            for key in "${ns_common[@]}" "${ns_named[@]}"; do ((i++)); ns_menu[$i]=$key; echo "  $i) $(ns_label "$key")"; done
+        fi
+        echo "  'all'     - every reference in the $style.index (no lamedb/bouquet)"
+        echo "  'enigma2' - filter against your enigma2 folder (lamedb/bouquet)"
+        echo "  'cancel'  - exit without building anything (or press Esc)"
+        printf "Enter number(s), position(s) (e.g. 28.2E), name(s) (e.g. Ziggo), 'all'/'enigma2' (no response defaults to 'enigma2'), or 'cancel': "
+        ns_answer=""
+        while IFS= read -rsn1 char; do
+            if [[ -z $char ]]; then
+                break
+            elif [[ $char == $'\x1b' ]]; then
+                # Lone Esc cancels; Esc-prefixed sequences (arrow keys etc.)
+                # are drained via a short timeout and otherwise ignored.
+                read -rsn2 -t 0.01 rest
+                if [[ -z $rest ]]; then
+                    echo ""
+                    echo "$(date +'%H:%M:%S') - INFO: Cancelled, nothing was built."
+                    exit 0
+                fi
+            elif [[ $char == $'\x7f' ]] || [[ $char == $'\x08' ]]; then
+                if [[ -n $ns_answer ]]; then
+                    ns_answer=${ns_answer%?}
+                    printf '\b \b'
+                fi
+            else
+                ns_answer+="$char"
+                printf '%s' "$char"
+            fi
+        done
+        echo ""
+        case $ns_answer in
+            cancel|quit|exit)
+                echo "$(date +'%H:%M:%S') - INFO: Cancelled, nothing was built."
+                exit 0
+                ;;
+            ""|enigma2) ns_mode="full" ;;
+            all) ns_mode="index" ;;
+            *)
+                ns_mode="orbital"
+                ns_selected=$(tr ',' '\n' <<< "$ns_answer" | while read -r tok; do resolve_ns_token "$tok"; done | sort -u)
+                ;;
+        esac
+    fi
+fi
+
+if [[ $ns_mode = "orbital" ]]; then
+    ################################################################
+    ## Orbital-position build: straight from the index, no        ##
+    ## lamedb/bouquet read or required.                           ##
+    ################################################################
+    file=$location/build-output/servicelist-enigma2-$style.txt
+    tempfile=$(mktemp --suffix=.servicelist)
+
+    patterns=()
+    while read -r key; do patterns+=("$(ns_pattern_index "$key")"); done <<< "$ns_selected"
+    index_regex=$(IFS='|'; echo "${patterns[*]}")
+
+    grep -E "$index_regex" <<< "$index" | while IFS='=' read -r key logo; do
+        echo -e "1_0_1_${key}_0_0_0\t\t${key}=${logo}" >> "$tempfile"
+    done
+
+    sort -t $'\t' -k 2,2 "$tempfile" | sed -e 's/\t/^|/g' | column -t -s $'^' | sed -e 's/|/  |  /g' > "$file"
+    rm "$tempfile"
+    echo "$(date +'%H:%M:%S') - INFO: Enigma2: Exported to $file (orbital-position filter, no lamedb/bouquet used)"
+elif [[ $ns_mode = "index" ]]; then
+    #####################################################################
+    ## Full index build: every entry in $style.index, no filtering,    ##
+    ## no lamedb/bouquet read or required.                             ##
+    #####################################################################
+    file=$location/build-output/servicelist-enigma2-$style.txt
+    tempfile=$(mktemp --suffix=.servicelist)
+
+    while IFS='=' read -r key logo; do
+        echo -e "1_0_1_${key}_0_0_0\t\t${key}=${logo}" >> "$tempfile"
+    done <<< "$index"
+
+    sort -t $'\t' -k 2,2 "$tempfile" | sed -e 's/\t/^|/g' | column -t -s $'^' | sed -e 's/|/  |  /g' > "$file"
+    rm "$tempfile"
+    echo "$(date +'%H:%M:%S') - INFO: Enigma2: Exported to $file (full index, no lamedb/bouquet used)"
+elif [[ -d $location/build-input/enigma2 ]]; then
     file=$location/build-output/servicelist-enigma2-$style.txt
     tempfile=$(mktemp --suffix=.servicelist)
     lamedb=$(<"$location/build-input/enigma2/lamedb")
@@ -145,7 +468,7 @@ if [[ -d $location/build-input/enigma2 ]]; then
     rm $tempfile "$bouquetmap"
     echo "$(date +'%H:%M:%S') - INFO: Enigma2: Exported to $file"
 else
-    echo "$(date +'%H:%M:%S') - ERROR: Enigma2: $location/build-input/enigma2 not found"
+    echo "$(date +'%H:%M:%S') - INFO: Enigma2: $location/build-input/enigma2 not found, skipping"
 fi
 
 ######################################################
@@ -231,7 +554,7 @@ if [[ -f $location/build-input/tvheadend.serverconf ]]; then
         echo "$(date +'%H:%M:%S') - ERROR: TvHeadend (server-mode): \"${TVH_HOST}\" is not reachable or has no channels."
     fi
 else
-    echo "$(date +'%H:%M:%S') - ERROR: TvHeadend (server-mode): $location/build-input/tvheadend.serverconf not found"
+    echo "$(date +'%H:%M:%S') - INFO: TvHeadend (server-mode): $location/build-input/tvheadend.serverconf not found, skipping"
 fi
 
 ##############################
@@ -303,7 +626,7 @@ if [[ -f $location/build-input/channels.conf ]]; then
     rm $tempfile
     echo "$(date +'%H:%M:%S') - INFO: VDR: Exported to $file"
 else
-    echo "$(date +'%H:%M:%S') - ERROR: VDR: $location/build-input/channels.conf not found"
+    echo "$(date +'%H:%M:%S') - INFO: VDR: $location/build-input/channels.conf not found, skipping"
 fi
 
 exit 0

--- a/README.md
+++ b/README.md
@@ -43,6 +43,30 @@ TIP: To automate the building process, you can also use some of the following co
 ./2-build-picons.sh snp-full
 ./2-build-picons.sh srp-full
 ```
+**Building SRP for specific providers and orbital positions**
+You can build Service Reference Picons for specific satellite orbital positions, Cable and Terrestrial providers
+
+```shell
+./1-build-servicelist.sh srp
+```
+A list of positions will be presented. Select the ones you want. You can select the numbered position, orbital position, name or ONID and namespace combination.
+For multiple selections, use a comma. Example below.
+```
+28.2E,23.5E,19.2E,13E,uk freeview,nld ziggo,531_EEEE0000
+
+```
+You can also build the list with options selected by the following.
+
+```
+./1-build-servicelist.sh srp "ziggo,13E,19.2E,23.5E,28.2E,uk freeview,nld ziggo,531_EEEE0000"
+```
+
+The above creates the `servicelist-enigma2-srp.txt` file. Start the build with the following.
+
+```shell
+./2-build-picons.sh srp
+```
+
 
 ## SNP - SERVICE NAME PICONS
 


### PR DESCRIPTION
This allows building picons by filtering the srp.index based on orbital positions, Cable and Terrestrial providers. The filtering is based on the srp.index only, no bouquets/lamedb are used.

Usage:
`./1-build-servicelist.sh srp`
This will provide choices for user to select.

Alternatively, if you know exactly what you want to build `./1-build-servicelist.sh srp "ziggo,13E,19.2E,23.5E,28.2E,uk freeview,nld ziggo,531_EEEE0000"`

The above creates `servicelist-enigma2-srp.txt`. The following starts the picon creation. `./2-build-picons.sh`

This is only for SRP.index. UTF8SNP is not specific  to orbital positions, so can't be filtered

Some Cable/Terrestrial provider names have been added for ease of reference.